### PR TITLE
fix: use pull request base as home

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ async function main() {
   const eventDataStr = await readFile(GITHUB_EVENT_PATH);
   const eventData = JSON.parse(eventDataStr);
 
-  if (!eventData || !eventData.pull_request || !eventData.pull_request.head) {
+  if (!eventData || !eventData.pull_request || !eventData.pull_request.base) {
     throw new Error(`Invalid GITHUB_EVENT_PATH contents: ${eventDataStr}`);
   }
 
@@ -50,8 +50,8 @@ async function main() {
   const isIgnored = parseIgnored(process.env.IGNORED);
 
   const pullRequestHome = {
-    owner: eventData.pull_request.head.repo.owner.login,
-    repo: eventData.pull_request.head.repo.name
+    owner: eventData.pull_request.base.repo.owner.login,
+    repo: eventData.pull_request.base.repo.name
   };
 
   const pull_number = eventData.pull_request.number;


### PR DESCRIPTION
When creating a PR from a fork it could previously not find the PR. See https://github.com/kudobuilder/kudo/pull/910/checks?check_run_id=252522591 as an example of this error.

Just for reference: if this is merged it will still fail, but with a 403, as long as you use the github token provided by the github action app installation  (https://github.com/kudobuilder/kudo/pull/910/checks?check_run_id=252648490) 