### PR TITLE
feat: do not fail on label remove error

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,11 +96,15 @@ async function main() {
 
   for (const label of remove) {
     debug("Removing label:", label);
-    await octokit.issues.removeLabel({
-      ...pullRequestHome,
-      issue_number: pull_number,
-      name: label
-    });
+    try {
+      await octokit.issues.removeLabel({
+        ...pullRequestHome,
+        issue_number: pull_number,
+        name: label
+      });
+    } catch (error) {
+      debug("Ignoring removing label error:", error);
+    }
   }
 
   debug("Success!");


### PR DESCRIPTION
Ignore errors on removing labels action.
In some cases, a previous action can be still running while a new one pops in, thus, there can be some state inconsistency where a run tries to delete a label that was already deleted.
