### PR TITLE
pull_request_target & permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,12 @@ Create a `.github/workflows/size-label.yml` file:
 
 ```yaml
 name: size-label
-on: pull_request
+on: pull_request_target
 jobs:
   size-label:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: size-label
@@ -69,9 +72,12 @@ You can pass your own configuration by passing `sizes`
 
 ```yaml
 name: size-label
-on: pull_request
+on: pull_request_target
 jobs:
   size-label:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: size-label


### PR DESCRIPTION
This PR is relatied to the issue https://github.com/pascalgn/size-label-action/issues/33

I found a best practice that resolves the issue.
https://github.com/actions/labeler/blob/a11f1c41635ff1796dffb74e7fa24cbcb92f66cf/README.md#create-workflow

The old workflow file no longer works.
To make it work fine, we need to change the event and add some permissions.

```yaml
name: size-label
## on: pull_request
on: pull_request_target
jobs:
  size-label:
    permissions: ## added
      contents: read
      pull-requests: write
    runs-on: ubuntu-latest
    steps:
      - name: size-label
        uses: "pascalgn/size-label-action@v0.4.3"
        env:
          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
```