### PR TITLE
Upgrade to Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: "Custom size configuration"
     required: false
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
 branding:
   icon: "tag"


### PR DESCRIPTION
GitHub Action runs now display a warning for this action:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: pascalgn/size-label-action@v0.4.3. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

This PR bumps the engine version to 16.

Closes #35 