### PR TITLE
Updated Readme to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: size-label
-        uses: "pascalgn/size-label-action@v0.4.2"
+        uses: "pascalgn/size-label-action@v0.5.0"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:


### PR DESCRIPTION
The size label action requires a version greater than 0.4.2 to run. This PR updates the readme to the latest version, which also supports the action