### PR TITLE
feat: use GITHUB_API_URL as baseUrl for octokit

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -64,6 +64,7 @@ async function main() {
 
   const octokit = new Octokit({
     auth: `token ${GITHUB_TOKEN}`,
+    baseUrl: process.env.GITHUB_API_URL || "https://api.github.com",
     userAgent: "pascalgn/size-label-action"
   });
 

--- a/index.js
+++ b/index.js
@@ -58,6 +58,7 @@ async function main() {
 
   const octokit = new Octokit({
     auth: `token ${GITHUB_TOKEN}`,
+    baseUrl: process.env.GITHUB_API_URL || "https://api.github.com",
     userAgent: "pascalgn/size-label-action"
   });
 


### PR DESCRIPTION
Hello @pascalgn,

to also allow to connect to GHE instances this change will use theAPI URL from the envs.
Instead of only supporting github.com this will allow to run the action also in dedicated GitHub Enterprise instances.

Similar to #40 but uses the [GH environment variable](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)`GITHUB_API_URL`.

closes #38