### PR TITLE
feat: add sizeLabel GITHUB_OUTPUT for further reuse in other jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,35 @@ jobs:
             }
 ```
 
+## Using with other actions
+
+If creating workflow with multiple jobs, they can react on the label set by this action:
+
+```yaml
+name: size-label
+on: pull_request_target
+jobs:
+  label:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    outputs:
+      label: ${{ steps.label.outputs.sizeLabel }}
+    steps:
+      - name: size-label
+        id: label
+        uses: "pascalgn/size-label-action@v0.5.0"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+  comment:
+    runs-on: ubuntu-latest
+    needs: label
+    if: ${{ contains(needs.label.outputs.label, 'XL') }}
+    steps:
+      - run: echo "Too big PR"
+```
+
 ## License
 
 [MIT](LICENSE)

--- a/dist/index.js
+++ b/dist/index.js
@@ -81,6 +81,13 @@ async function main() {
   const sizes = getSizesInput();
   const sizeLabel = getSizeLabel(changedLines, sizes);
   console.log("Matching label:", sizeLabel);
+  debug(`Writing label to ${process.env.GITHUB_OUTPUT}`);
+  try {
+    fs.writeFileSync(process.env.GITHUB_OUTPUT, `sizeLabel="${sizeLabel}"`);
+    debug("Writing finished");
+  } catch (err) {
+    console.error(`Couldn't write to GH Action output: ${err}`);
+  }
 
   const { add, remove } = getLabelChanges(
     sizeLabel,

--- a/dist/index.js
+++ b/dist/index.js
@@ -81,12 +81,11 @@ async function main() {
   const sizes = getSizesInput();
   const sizeLabel = getSizeLabel(changedLines, sizes);
   console.log("Matching label:", sizeLabel);
-  debug(`Writing label to ${process.env.GITHUB_OUTPUT}`);
-  try {
-    fs.writeFileSync(process.env.GITHUB_OUTPUT, `sizeLabel="${sizeLabel}"`);
-    debug("Writing finished");
-  } catch (err) {
-    console.error(`Couldn't write to GH Action output: ${err}`);
+
+  const githubOutput = process.env.GITHUB_OUTPUT;
+  if (githubOutput) {
+    fs.writeFileSync(githubOutput, `sizeLabel="${sizeLabel}"`);
+    debug(`Written label '${sizeLabel}' to ${githubOutput}`);
   }
 
   const { add, remove } = getLabelChanges(

--- a/index.js
+++ b/index.js
@@ -75,12 +75,11 @@ async function main() {
   const sizes = getSizesInput();
   const sizeLabel = getSizeLabel(changedLines, sizes);
   console.log("Matching label:", sizeLabel);
-  debug(`Writing label to ${process.env.GITHUB_OUTPUT}`);
-  try {
-    fs.writeFileSync(process.env.GITHUB_OUTPUT, `sizeLabel="${sizeLabel}"`);
-    debug("Writing finished");
-  } catch (err) {
-    console.error(`Couldn't write to GH Action output: ${err}`);
+
+  const githubOutput = process.env.GITHUB_OUTPUT;
+  if (githubOutput) {
+    fs.writeFileSync(githubOutput, `sizeLabel="${sizeLabel}"`);
+    debug(`Written label '${sizeLabel}' to ${githubOutput}`);
   }
 
   const { add, remove } = getLabelChanges(

--- a/index.js
+++ b/index.js
@@ -75,6 +75,13 @@ async function main() {
   const sizes = getSizesInput();
   const sizeLabel = getSizeLabel(changedLines, sizes);
   console.log("Matching label:", sizeLabel);
+  debug(`Writing label to ${process.env.GITHUB_OUTPUT}`);
+  try {
+    fs.writeFileSync(process.env.GITHUB_OUTPUT, `sizeLabel="${sizeLabel}"`);
+    debug("Writing finished");
+  } catch (err) {
+    console.error(`Couldn't write to GH Action output: ${err}`);
+  }
 
   const { add, remove } = getLabelChanges(
     sizeLabel,


### PR DESCRIPTION
I wanted my GitHub Workflow to comment in the PR (using https://github.com/thollander/actions-comment-pull-request) in case its size is too big.

I tried using `github.event.pull_request.labels.*.name`, but it contains a previous PR state (without a newly added size label), so I needed to be more proactive and added writing to `GITHUB_OUTPUT` file right from the Action script to capture the assigned `sizeLabel`.