### PR TITLE
docs: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: size-label
-        uses: "pascalgn/size-label-action@v0.4.2"
+        uses: "pascalgn/size-label-action@v0.5.0"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:


### PR DESCRIPTION
Because of `pascalgn/size-label-action@v0.4.2` dont include input `size` feature, so the example code is incorrect.

this input params is only provide by `v0.5.0`