### PR TITLE
Upgrade to node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: "Custom size configuration"
     required: false
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"
 branding:
   icon: "tag"


### PR DESCRIPTION
Upgrading to node 20 to fix`Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: pascalgn/size-label-action@v0.5.0. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.`


![image](https://github.com/pascalgn/size-label-action/assets/138790167/02cf8e18-b7fe-48cf-93a6-dd8875e3f89a)
