### PR TITLE
Update node 16 to 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: "Custom size configuration"
     required: false
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"
 branding:
   icon: "tag"


### PR DESCRIPTION
This is the fix for [Node.js 16 is deprecated](https://github.com/pascalgn/size-label-action/issues/47)