### PR TITLE
chore: use actions-tagger to promote a major tag on every release

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,0 +1,14 @@
+name: 'Publish major version'
+
+on:
+  release:
+    types: [published, edited]
+
+permissions:
+  deployments: write
+
+jobs:
+  actions-tagger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Actions-R-Us/actions-tagger@v2

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 !.dockerignore
 !.eslintrc.json
 !.gitignore
+!.github
 
 node_modules/


### PR DESCRIPTION
According to the github actions [versioning guide](https://github.com/actions/toolkit/blob/master/docs/action-versioning.md#versioning), actions publishers should have a major tag (v1, v2, etc) which points to the latest version of any minor/patch release of their action, for ease of use by the others.

This action doesn't currently do that, so I am leveraging the [actions-tagger](https://github.com/Actions-R-Us/actions-tagger) here, which will push a new major tag on every release.

Happy to get feedback!