### PR TITLE
Bump Node version used to 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: "Custom size configuration"
     required: false
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"
 branding:
   icon: "tag"


### PR DESCRIPTION
Node 20 support is being remove in June ([blog]([Deprecation of Node 20 on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/))).

I ran the tests locally using v24 and they passed fine. @pascalgn mind taking a look?